### PR TITLE
Exit with nonzero status code on build failure

### DIFF
--- a/scripts/bts.sh
+++ b/scripts/bts.sh
@@ -99,7 +99,12 @@ function run {
   logfn=`mktemp --suffix=.log`
 
   # Compile and link
-  battlestarc -bits="$bits" -osx="$osx" -f $1 -o "$asmfn" -oc "$cfn" 2>"$logfn" || (cat "$logfn"; rm "$asmfn"; echo "$1 failed to build.")
+  if ! battlestarc -bits="$bits" -osx="$osx" -f $1 -o "$asmfn" -oc "$cfn" 2>"$logfn"; then
+    cat "$logfn"
+    rm "$asmfn"
+    echo "$1 failed to build."
+    exit 1
+  fi
   if [ -e "$asmfn" ]; then
     [ -e $cfn ] && ($cccmd -c "$cfn" -o "${o2fn}" || echo "$1 failed to compile")
     [ -e $asmfn ] && ($asmcmd -o "$o1fn" "$asmfn" || echo "$1 failed to assemble")


### PR DESCRIPTION
Currently if there is a compilation error, the message `failed to build` is displayed, but `bts` exits with a status code of zero nonetheless, indicating success.

This PR updates the behavior to be the same as before except that the status code is 1 instead of 0 when there is a compilation error.